### PR TITLE
Reduced redundancy in Elements handling

### DIFF
--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -36,6 +36,7 @@ namespace FFTPatcher.Datatypes
         Holy = 6,
         Dark = 7,
     }
+    //Try to find a way to combine this with `Elements`.
     public enum ElementFlags : byte
     {
         Fire = 1,
@@ -64,9 +65,11 @@ namespace FFTPatcher.Datatypes
             [Element.Holy] = "Holy",
             [Element.Dark] = "Dark",
         };
-        private static readonly IList<string> elementNames = Utilities.GetValues<Element>()
-                                                                      .Select(el => Strings[el])
-                                                                      .ToList();
+        private static readonly IList<string> elementNames =
+            Utilities.GetValues<Element>()
+                .Select(el => Strings[el])
+                .ToList()
+                .AsReadOnly();
 
 
         #endregion Instance Variables 

--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -21,31 +21,57 @@ using System;
 using System.Collections.Generic;
 using PatcherLib;
 using PatcherLib.Utilities;
+using System.Linq;
 
 namespace FFTPatcher.Datatypes
 {
+    public enum Element
+    {
+        Fire = 0,
+        Lightning = 1,
+        Ice = 2,
+        Wind = 3,
+        Earth = 4,
+        Water = 5,
+        Holy = 6,
+        Dark = 7,
+    }
+    public enum ElementFlags : byte
+    {
+        Fire = 1,
+        Lightning = 2,
+        Ice = 4,
+        Wind = 8,
+        Earth = 16,
+        Water = 32,
+        Holy = 64,
+        Dark = 128,
+    }
+
     public class Elements : BaseDataType, IEquatable<Elements>, ISupportDigest, ISupportDefault<Elements>
     {
-		#region Instance Variables (1) 
+        #region Instance Variables (1) 
 
-        private static class Strings
+        //TODO: Read this from XML file?
+        private static readonly IDictionary<Element, string> Strings = new Dictionary<Element, string>
         {
-            public const string Fire = "Fire";
-            public const string Lightning = "Lightning";
-            public const string Ice = "Ice";
-            public const string Wind = "Wind";
-            public const string Earth = "Earth";
-            public const string Water = "Water";
-            public const string Holy = "Holy";
-            public const string Dark = "Dark";
-        }
-        private static readonly string[] elementNames = new string[8] {
-            Strings.Fire, Strings.Lightning, Strings.Ice, Strings.Wind,
-            Strings.Earth, Strings.Water, Strings.Holy, Strings.Dark };
+            [Element.Fire] = "Fire",
+            [Element.Lightning] = "Lightning",
+            [Element.Ice] = "Ice",
+            [Element.Wind] = "Wind",
+            [Element.Earth] = "Earth",
+            [Element.Water] = "Water",
+            [Element.Holy] = "Holy",
+            [Element.Dark] = "Dark",
+        };
+        private static readonly IList<string> elementNames = Utilities.GetValues<Element>()
+                                                                      .Select(el => Strings[el])
+                                                                      .ToList();
+        
 
-		#endregion Instance Variables 
+        #endregion Instance Variables 
 
-		#region Public Properties (11) 
+        #region Public Properties (11) 
 
         public bool Dark { get; set; }
 
@@ -62,7 +88,7 @@ namespace FFTPatcher.Datatypes
 
         public bool HasChanged
         {
-            get { return !Equals( Default ); }
+            get { return !Equals(Default); }
         }
 
         public bool Holy { get; set; }
@@ -75,22 +101,22 @@ namespace FFTPatcher.Datatypes
 
         public bool Wind { get; set; }
 
-		#endregion Public Properties 
+        #endregion Public Properties 
 
-		#region Constructors (1) 
+        #region Constructors (1) 
 
-        public Elements( byte b )
+        public Elements(byte b)
         {
-            PopulateFromBools( PatcherLib.Utilities.Utilities.BooleansFromByte( b ) );
+            PopulateFromBools(PatcherLib.Utilities.Utilities.BooleansFromByte(b));
         }
 
         internal Elements()
         {
         }
 
-        private void PopulateFromBools( IList<bool> bools )
+        private void PopulateFromBools(IList<bool> bools)
         {
-            System.Diagnostics.Debug.Assert( bools.Count == 8 );
+            System.Diagnostics.Debug.Assert(bools.Count == 8);
             Fire = bools[7];
             Lightning = bools[6];
             Ice = bools[5];
@@ -101,11 +127,11 @@ namespace FFTPatcher.Datatypes
             Dark = bools[0];
         }
 
-		#endregion Constructors 
+        #endregion Constructors 
 
-		#region Public Methods (8) 
+        #region Public Methods (8) 
 
-        public static void Copy( Elements source, Elements destination )
+        public static void Copy(Elements source, Elements destination)
         {
             destination.Fire = source.Fire;
             destination.Lightning = source.Lightning;
@@ -117,12 +143,12 @@ namespace FFTPatcher.Datatypes
             destination.Dark = source.Dark;
         }
 
-        public void CopyTo( Elements destination )
+        public void CopyTo(Elements destination)
         {
-            Copy( this, destination );
+            Copy(this, destination);
         }
 
-        public bool Equals( Elements other )
+        public bool Equals(Elements other)
         {
             return
                 other != null &&
@@ -136,15 +162,15 @@ namespace FFTPatcher.Datatypes
                 other.Dark == Dark;
         }
 
-        public override bool Equals( object obj )
+        public override bool Equals(object obj)
         {
-            if( obj is Elements )
+            if (obj is Elements)
             {
-                return Equals( obj as Elements );
+                return Equals(obj as Elements);
             }
             else
             {
-                return base.Equals( obj );
+                return base.Equals(obj);
             }
         }
 
@@ -161,31 +187,31 @@ namespace FFTPatcher.Datatypes
 
         public byte ToByte()
         {
-            return PatcherLib.Utilities.Utilities.ByteFromBooleans( Fire, Lightning, Ice, Wind, Earth, Water, Holy, Dark );
+            return PatcherLib.Utilities.Utilities.ByteFromBooleans(Fire, Lightning, Ice, Wind, Earth, Water, Holy, Dark);
         }
 
         public override string ToString()
         {
-            List<string> strings = new List<string>( 8 );
-            foreach( string name in elementNames )
+            List<string> strings = new List<string>(8);
+            foreach (string name in elementNames)
             {
-                if( ReflectionHelpers.GetFieldOrProperty<bool>( this, name ) )
+                if (ReflectionHelpers.GetFieldOrProperty<bool>(this, name))
                 {
-                    strings.Add( name );
+                    strings.Add(name);
                 }
             }
-            return string.Join( " | ", strings.ToArray() );
+            return string.Join(" | ", strings.ToArray());
         }
 
-		#endregion Public Methods 
-    
+        #endregion Public Methods 
+
         protected override void WriteXml(System.Xml.XmlWriter writer)
         {
             bool[] bools = ToBoolArray();
-            System.Diagnostics.Debug.Assert( bools.Length == DigestableProperties.Count );
-            for ( int i = 0; i < bools.Length; i++ )
+            System.Diagnostics.Debug.Assert(bools.Length == DigestableProperties.Count);
+            for (int i = 0; i < bools.Length; i++)
             {
-                writer.WriteValueElement( DigestableProperties[i], bools[i] );
+                writer.WriteValueElement(DigestableProperties[i], bools[i]);
             }
         }
 
@@ -193,11 +219,11 @@ namespace FFTPatcher.Datatypes
         {
             reader.ReadStartElement();
             bool[] bools = new bool[8];
-            for ( int i = 0; i < bools.Length; i++ )
+            for (int i = 0; i < bools.Length; i++)
             {
                 bools[i] = reader.ReadElementContentAsBoolean();
             }
-            PopulateFromBools( bools );
+            PopulateFromBools(bools);
             reader.ReadEndElement();
         }
     }

--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -62,18 +62,6 @@ namespace FFTPatcher.Datatypes
     {
         #region Instance Variables (1) 
 
-        //TODO: Read this from XML file?
-        public static IDictionary<Element, string> ElementNames = new Dictionary<Element, string>
-        {
-            [Element.Fire] = "Fire",
-            [Element.Lightning] = "Lightning",
-            [Element.Ice] = "Ice",
-            [Element.Wind] = "Wind",
-            [Element.Earth] = "Earth",
-            [Element.Water] = "Water",
-            [Element.Holy] = "Holy",
-            [Element.Dark] = "Dark",
-        };
         /// <summary>
         /// Properties of the class for digest purposes.
         /// Order matters.
@@ -152,7 +140,14 @@ namespace FFTPatcher.Datatypes
             set => this[Element.Dark] = value;
         }
 
-        public Elements Default { get; set; }
+        /// <summary>
+        /// This is not really part of the public interface of the class.
+        /// It's a cached value, saving details of how this object is used.
+        /// It should be annotated as such.
+        /// 
+        /// In ideal OOP, it wouldn't be saved in here, but rather saved by its user.
+        /// </summary>
+        public Elements Default { get; set; } = null;
 
         public IList<string> DigestableProperties
         {
@@ -198,7 +193,7 @@ namespace FFTPatcher.Datatypes
         public static void Copy(Elements source, Elements destination)
         {
             destination.Flags = source.Flags;
-            //Doesn't copy Defaults because that'd be recursive?
+            //Note that it doesn't copy Defaults.
         }
 
         public void CopyTo(Elements destination)

--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -272,6 +272,7 @@ namespace FFTPatcher.Datatypes
             {
                 bools[i] = reader.ReadElementContentAsBoolean();
             }
+            Array.Reverse(bools);
             PopulateFromBoolsMSB(bools);
             reader.ReadEndElement();
         }

--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -67,7 +67,7 @@ namespace FFTPatcher.Datatypes
         private static readonly IList<string> elementNames = Utilities.GetValues<Element>()
                                                                       .Select(el => Strings[el])
                                                                       .ToList();
-        
+
 
         #endregion Instance Variables 
 

--- a/Datatypes/Elements.cs
+++ b/Datatypes/Elements.cs
@@ -66,16 +66,22 @@ namespace FFTPatcher.Datatypes
         /// Properties of the class for digest purposes.
         /// Order matters.
         /// </summary>
-        private static readonly string[] propertyNames = {
-            "Fire",
-            "Lightning",
-            "Ice",
-            "Wind",
-            "Earth",
-            "Water",
-            "Holy",
-            "Dark",
+        private static readonly Element[] elementOrder =
+        {
+            Element.Fire,
+            Element.Lightning,
+            Element.Ice,
+            Element.Wind,
+            Element.Earth,
+            Element.Water,
+            Element.Holy,
+            Element.Dark,
         };
+        private static readonly IList<string> propertyNames =
+            elementOrder
+            .Select(e => e.ToString())
+            .ToList()
+            .AsReadOnly();
 
         #endregion Instance Variables 
 
@@ -141,18 +147,18 @@ namespace FFTPatcher.Datatypes
         }
 
         /// <summary>
+        /// Defaults for this flagset.
+        /// 
         /// This is not really part of the public interface of the class.
         /// It's a cached value, saving details of how this object is used.
         /// It should be annotated as such.
         /// 
-        /// In ideal OOP, it wouldn't be saved in here, but rather saved by its user.
+        /// In ideal OOP, it wouldn't be saved in here, but instead saved by its user.
         /// </summary>
         public Elements Default { get; set; } = null;
 
-        public IList<string> DigestableProperties
-        {
-            get { return propertyNames; }
-        }
+        //Why isn't this static?
+        public IList<string> DigestableProperties { get; } = propertyNames;
 
 
         public bool HasChanged
@@ -236,15 +242,9 @@ namespace FFTPatcher.Datatypes
 
         public override string ToString()
         {
-            List<string> strings = new List<string>(8);
-            foreach (string name in propertyNames)
-            {
-                if (ReflectionHelpers.GetFieldOrProperty<bool>(this, name))
-                {
-                    strings.Add(name);
-                }
-            }
-            return string.Join(" | ", strings.ToArray());
+            bool[] bools = ToBoolArray();
+            var names = propertyNames.Where((name, i) => bools[i]);
+            return string.Join(" | ", names.ToArray());  //Don't need ToArray in newer .NET.
         }
 
         #endregion Public Methods 
@@ -252,10 +252,10 @@ namespace FFTPatcher.Datatypes
         protected override void WriteXml(System.Xml.XmlWriter writer)
         {
             bool[] bools = ToBoolArray();
-            System.Diagnostics.Debug.Assert(bools.Length == DigestableProperties.Count);
+            System.Diagnostics.Debug.Assert(bools.Length == propertyNames.Count);
             for (int i = 0; i < bools.Length; i++)
             {
-                writer.WriteValueElement(DigestableProperties[i], bools[i]);
+                writer.WriteValueElement(propertyNames[i], bools[i]);
             }
         }
 

--- a/Datatypes/Propositions/AllPropositions.cs
+++ b/Datatypes/Propositions/AllPropositions.cs
@@ -5,6 +5,7 @@ using PatcherLib.Utilities;
 using PatcherLib.Datatypes;
 using PatcherLib;
 using Lokad;
+using System.Linq;
 
 namespace FFTPatcher.Datatypes
 {
@@ -198,9 +199,9 @@ namespace FFTPatcher.Datatypes
 
             propTypeBonuses = new TupleDictionary<PropositionType, PropositionClass, byte>();
 
-            foreach (PropositionType type in (PropositionType[])Enum.GetValues( typeof( PropositionType ) ))
+            foreach (PropositionType type in Utilities.GetValues<PropositionType>())
             {
-                foreach (PropositionClass _class in (PropositionClass[])Enum.GetValues( typeof( PropositionClass ) ))
+                foreach (PropositionClass _class in Utilities.GetValues<PropositionClass>())
                 {
                     propTypeBonuses[type, _class] = bytes[0x8C0 + ((int)type - 1) * 22 + (int)_class];
                 }
@@ -208,9 +209,9 @@ namespace FFTPatcher.Datatypes
             propTypeBonuses = new TupleDictionary<PropositionType, PropositionClass, byte>( propTypeBonuses, false, true );
 
             bfBonuses = new TupleDictionary<BraveFaithNeutral, PropositionClass, byte>();
-            foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) ))
+            foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
-                foreach (PropositionClass _class in (PropositionClass[])Enum.GetValues( typeof( PropositionClass ) ))
+                foreach (PropositionClass _class in Utilities.GetValues<PropositionClass>())
                 {
                     bfBonuses[bfn, _class] = bytes[0x970 + ((int)bfn - 1) * 22 + (int)_class];
                 }
@@ -224,15 +225,15 @@ namespace FFTPatcher.Datatypes
             //int levelBonusesOffset = brokenLevelBonuses ? 0x9B4 : 0x9D4;
             int levelBonusesOffset = 0x9D4;
             
-            foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) ))
+            foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
-                foreach (BraveFaithRange range in (BraveFaithRange[])Enum.GetValues( typeof( BraveFaithRange ) ))
+                foreach (BraveFaithRange range in Utilities.GetValues<BraveFaithRange>())
                 {
                     braveBonuses[bfn, range] = bytes[0x9B4 + ((int)bfn - 1) * 5 + (int)range];
                     faithBonuses[bfn, range] = bytes[0x9C4 + ((int)bfn - 1) * 5 + (int)range];
                 }
 
-                foreach (LevelRange range in (LevelRange[])Enum.GetValues( typeof( LevelRange ) ))
+                foreach (LevelRange range in Utilities.GetValues<LevelRange>())
                 {
                     levelBonuses[bfn, range] = bytes[levelBonusesOffset + ((int)bfn - 1) * 10 + (int)range];
                 }
@@ -248,7 +249,7 @@ namespace FFTPatcher.Datatypes
             bonusCashGilBonuses = new TupleDictionary<PropositionType, BonusPercent, BonusIndex>();
             bonusCashJpBonuses = new TupleDictionary<PropositionType, BonusPercent, BonusIndex>();
 
-            foreach (PropositionType type in (PropositionType[])Enum.GetValues( typeof( PropositionType ) ))
+            foreach (PropositionType type in Utilities.GetValues<PropositionType>())
             {
                 treasureLandGilBonuses[type] = (BonusIndex)bytes[0x9F4 + 2 * ((int)type - 1)];
                 treasureLandJpBonuses[type] = (BonusIndex)bytes[0x9F4 + 2 * ((int)type - 1) + 1];
@@ -325,8 +326,8 @@ namespace FFTPatcher.Datatypes
             Prices.ForEach( p => result.AddRange( p.ToBytes() ) );
             result.AddRange( unknownBytes );
 
-            PropositionClass[] classes = (PropositionClass[])Enum.GetValues( typeof( PropositionClass ) );
-            PropositionType[] propTypes = (PropositionType[])Enum.GetValues( typeof( PropositionType ) );
+            IList<PropositionClass> classes = Utilities.GetValues<PropositionClass>().ToList();
+            IList<PropositionType> propTypes = Utilities.GetValues<PropositionType>().ToList();
             foreach (PropositionType type in propTypes)
             {
                 foreach (PropositionClass _class in classes)
@@ -334,7 +335,7 @@ namespace FFTPatcher.Datatypes
                     result.Add( propTypeBonuses[type, _class] );
                 }
             }
-            BraveFaithNeutral[] bfnVals = (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) );
+            IList<BraveFaithNeutral> bfnVals = Utilities.GetValues<BraveFaithNeutral>().ToList();
             foreach (BraveFaithNeutral bfn in bfnVals)
             {
                 foreach (PropositionClass _class in classes)
@@ -345,7 +346,7 @@ namespace FFTPatcher.Datatypes
 
             result.Add( 0x00 );
             result.Add( 0x00 );
-            BraveFaithRange[] bfnRanges = (BraveFaithRange[])Enum.GetValues( typeof( BraveFaithRange ) );
+            IList<BraveFaithRange> bfnRanges = Utilities.GetValues<BraveFaithRange>().ToList();
 
             foreach (BraveFaithNeutral bfn in bfnVals)
             {
@@ -367,7 +368,7 @@ namespace FFTPatcher.Datatypes
 
             result.Add( 0x00 );
 
-            LevelRange[] levelRanges = (LevelRange[])Enum.GetValues( typeof( LevelRange ) );
+            IList<LevelRange> levelRanges = Utilities.GetValues<LevelRange>().ToList();
             foreach (BraveFaithNeutral bfn in bfnVals)
             {
                 foreach (LevelRange range in levelRanges)

--- a/Editors/Abilities/AbilityEditor.cs
+++ b/Editors/Abilities/AbilityEditor.cs
@@ -23,6 +23,8 @@ using FFTPatcher.Controls;
 using FFTPatcher.Datatypes;
 using PatcherLib.Datatypes;
 using PatcherLib;
+using PatcherLib.Utilities;
+using System.Linq;
 
 namespace FFTPatcher.Editors
 {
@@ -31,14 +33,14 @@ namespace FFTPatcher.Editors
 		#region Instance Variables
 
         private Ability ability;
-        private List<ComboBoxWithDefault> comboBoxes;
+        private IList<ComboBoxWithDefault> comboBoxes;
         private bool ignoreChanges = false;
         private Context ourContext = Context.Default;
-        private List<Item> pspItems = new List<Item>( 256 );
-        private List<ItemSubType> pspItemTypes = new List<ItemSubType>( (ItemSubType[])Enum.GetValues( typeof( ItemSubType ) ) );
-        private List<Item> psxItems = new List<Item>( 256 );
-        private List<ItemSubType> psxItemTypes = new List<ItemSubType>( (ItemSubType[])Enum.GetValues( typeof( ItemSubType ) ) );
-        private List<NumericUpDownWithDefault> spinners;
+        private IList<Item> pspItems = new List<Item>( 256 );
+        private IList<ItemSubType> pspItemTypes = Utilities.GetValues<ItemSubType>().ToList();
+        private IList<Item> psxItems = new List<Item>( 256 );
+        private IList<ItemSubType> psxItemTypes = Utilities.GetValues<ItemSubType>().ToList();
+        private IList<NumericUpDownWithDefault> spinners;
 
 		#endregion Instance Variables 
 

--- a/Editors/ElementsEditor.Designer.cs
+++ b/Editors/ElementsEditor.Designer.cs
@@ -69,15 +69,7 @@ namespace FFTPatcher.Editors
             // 
             this.elementsCheckedListBox.CheckOnClick = true;
             this.elementsCheckedListBox.FormattingEnabled = true;
-            this.elementsCheckedListBox.Items.AddRange(new object[] {
-            "Fire",
-            "Lightning",
-            "Ice",
-            "Wind",
-            "Earth",
-            "Water",
-            "Holy",
-            "Dark"});
+            this.elementsCheckedListBox.Items.AddRange(elementNames);
             this.elementsCheckedListBox.Location = new System.Drawing.Point(6, 19);
             this.elementsCheckedListBox.Name = "elementsCheckedListBox";
             this.elementsCheckedListBox.Size = new System.Drawing.Size(82, 124);

--- a/Editors/ElementsEditor.cs
+++ b/Editors/ElementsEditor.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using FFTPatcher.Datatypes;
+using static FFTPatcher.Datatypes.Elements;
 using PatcherLib;
 
 namespace FFTPatcher.Editors
@@ -32,8 +33,6 @@ namespace FFTPatcher.Editors
         #region Instance Variables (4) 
 
         private Elements defaults;
-        private static string[] elementNames = new string[] {
-                "Fire", "Lightning", "Ice", "Wind", "Earth", "Water", "Holy", "Dark" };
         private Elements elements = new Elements(0);
         private bool ignoreChanges = false;
 
@@ -90,7 +89,7 @@ namespace FFTPatcher.Editors
             elementsCheckedListBox.SuspendLayout();
 
             ignoreChanges = true;
-            elementsCheckedListBox.SetValuesAndDefaults(ReflectionHelpers.GetFieldsOrProperties<bool>(elements, elementNames), ReflectionHelpers.GetFieldsOrProperties<bool>(defaults, elementNames));
+            elementsCheckedListBox.SetValuesAndDefaults(elements.ToBoolArray(), defaults.ToBoolArray());
             ignoreChanges = false;
 
             elementsCheckedListBox.ResumeLayout();
@@ -102,17 +101,6 @@ namespace FFTPatcher.Editors
 
         private class ElementsCheckedListBox : CheckedListBox
         {
-            private enum Elements
-            {
-                Fire,
-                Lightning,
-                Ice,
-                Wind,
-                Earth,
-                Water,
-                Holy,
-                Dark
-            }
             public bool[] Defaults { get; private set; }
             public ElementsCheckedListBox()
                 : base()
@@ -160,37 +148,37 @@ namespace FFTPatcher.Editors
                 Brush backColorBrush = Brushes.White;
                 Brush foreColorBrush = Brushes.Black;
 
-                switch ((Elements)e.Index)
+                switch ((Element)e.Index)
                 {
-                    case Elements.Fire:
+                    case Element.Fire:
                         backColorBrush = Brushes.Red;
                         foreColorBrush = Brushes.White;
                         break;
-                    case Elements.Lightning:
+                    case Element.Lightning:
                         backColorBrush = Brushes.Purple; // TODO: find a better color
                         foreColorBrush = Brushes.White;
                         break;
-                    case Elements.Ice:
+                    case Element.Ice:
                         backColorBrush = Brushes.LightCyan;
                         foreColorBrush = Brushes.Black;
                         break;
-                    case Elements.Wind:
+                    case Element.Wind:
                         backColorBrush = Brushes.Yellow;
                         foreColorBrush = Brushes.Black;
                         break;
-                    case Elements.Earth:
+                    case Element.Earth:
                         backColorBrush = Brushes.Green;
                         foreColorBrush = Brushes.White;
                         break;
-                    case Elements.Water:
+                    case Element.Water:
                         backColorBrush = Brushes.LightBlue;
                         foreColorBrush = Brushes.Black;
                         break;
-                    case Elements.Holy:
+                    case Element.Holy:
                         backColorBrush = Brushes.White;
                         foreColorBrush = Brushes.Black;
                         break;
-                    case Elements.Dark:
+                    case Element.Dark:
                         backColorBrush = Brushes.Black;
                         foreColorBrush = Brushes.White;
                         break;

--- a/Editors/ElementsEditor.cs
+++ b/Editors/ElementsEditor.cs
@@ -29,17 +29,17 @@ namespace FFTPatcher.Editors
 {
     public partial class ElementsEditor : BaseEditor
     {
-		#region Instance Variables (4) 
+        #region Instance Variables (4) 
 
         private Elements defaults;
         private static string[] elementNames = new string[] {
                 "Fire", "Lightning", "Ice", "Wind", "Earth", "Water", "Holy", "Dark" };
-        private Elements elements = new Elements( 0 );
+        private Elements elements = new Elements(0);
         private bool ignoreChanges = false;
 
-		#endregion Instance Variables 
+        #endregion Instance Variables 
 
-		#region Public Properties (1) 
+        #region Public Properties (1) 
 
         public string GroupBoxText
         {
@@ -47,9 +47,9 @@ namespace FFTPatcher.Editors
             set { elementsGroupBox.Text = value; }
         }
 
-		#endregion Public Properties 
+        #endregion Public Properties 
 
-		#region Constructors (1) 
+        #region Constructors (1) 
 
         public ElementsEditor()
         {
@@ -57,11 +57,11 @@ namespace FFTPatcher.Editors
             elementsCheckedListBox.ItemCheck += elementsCheckedListBox_ItemCheck;
         }
 
-		#endregion Constructors 
+        #endregion Constructors 
 
-		#region Public Methods (1) 
+        #region Public Methods (1) 
 
-        public void SetValueAndDefaults( Elements value, Elements defaults )
+        public void SetValueAndDefaults(Elements value, Elements defaults)
         {
             elements = value;
             this.defaults = defaults;
@@ -69,18 +69,18 @@ namespace FFTPatcher.Editors
             UpdateView();
         }
 
-		#endregion Public Methods 
+        #endregion Public Methods 
 
-		#region Private Methods (2) 
+        #region Private Methods (2) 
 
-        private void elementsCheckedListBox_ItemCheck( object sender, ItemCheckEventArgs e )
+        private void elementsCheckedListBox_ItemCheck(object sender, ItemCheckEventArgs e)
         {
-            if( !ignoreChanges )
+            if (!ignoreChanges)
             {
                 string s = elementsCheckedListBox.Items[e.Index].ToString();
-                PropertyInfo pi = elements.GetType().GetProperty( s );
-                pi.SetValue( elements, e.NewValue == CheckState.Checked, null );
-                OnDataChanged( this, System.EventArgs.Empty );
+                PropertyInfo pi = elements.GetType().GetProperty(s);
+                pi.SetValue(elements, e.NewValue == CheckState.Checked, null);
+                OnDataChanged(this, System.EventArgs.Empty);
             }
         }
 
@@ -90,14 +90,14 @@ namespace FFTPatcher.Editors
             elementsCheckedListBox.SuspendLayout();
 
             ignoreChanges = true;
-            elementsCheckedListBox.SetValuesAndDefaults( ReflectionHelpers.GetFieldsOrProperties<bool>( elements, elementNames ), ReflectionHelpers.GetFieldsOrProperties<bool>( defaults, elementNames ) );
+            elementsCheckedListBox.SetValuesAndDefaults(ReflectionHelpers.GetFieldsOrProperties<bool>(elements, elementNames), ReflectionHelpers.GetFieldsOrProperties<bool>(defaults, elementNames));
             ignoreChanges = false;
 
             elementsCheckedListBox.ResumeLayout();
             this.ResumeLayout();
         }
 
-		#endregion Private Methods 
+        #endregion Private Methods 
 
 
         private class ElementsCheckedListBox : CheckedListBox
@@ -113,54 +113,54 @@ namespace FFTPatcher.Editors
                 Holy,
                 Dark
             }
-public bool[] Defaults { get; private set; }
+            public bool[] Defaults { get; private set; }
             public ElementsCheckedListBox()
                 : base()
             {
                 CheckOnClick = true;
             }
-            public void SetValuesAndDefaults( bool[] values, bool[] defaults )
+            public void SetValuesAndDefaults(bool[] values, bool[] defaults)
             {
-                if( (values != null) && (defaults != null) && (this.Defaults == null) )
+                if ((values != null) && (defaults != null) && (this.Defaults == null))
                 {
                     this.Defaults = defaults;
-                    for( int i = 0; i < values.Length; i++ )
+                    for (int i = 0; i < values.Length; i++)
                     {
-                        SetItemChecked( i, values[i] );
-                        RefreshItem( i );
+                        SetItemChecked(i, values[i]);
+                        RefreshItem(i);
                     }
                 }
-                else if( (values != null) && (defaults != null) && (this.Defaults != null) )
+                else if ((values != null) && (defaults != null) && (this.Defaults != null))
                 {
-                    List<int> itemsToRefresh = new List<int>( values.Length );
-                    for( int i = 0; i < values.Length; i++ )
+                    List<int> itemsToRefresh = new List<int>(values.Length);
+                    for (int i = 0; i < values.Length; i++)
                     {
-                        if( ((GetItemChecked( i ) ^ this.Defaults[i]) && !(values[i] ^ defaults[i])) ||
-                            (!(GetItemChecked( i ) ^ this.Defaults[i]) && (values[i] ^ defaults[i])) )
+                        if (((GetItemChecked(i) ^ this.Defaults[i]) && !(values[i] ^ defaults[i])) ||
+                            (!(GetItemChecked(i) ^ this.Defaults[i]) && (values[i] ^ defaults[i])))
                         {
-                            itemsToRefresh.Add( i );
+                            itemsToRefresh.Add(i);
                         }
                     }
 
                     this.Defaults = defaults;
-                    for( int i = 0; i < values.Length; i++ )
+                    for (int i = 0; i < values.Length; i++)
                     {
-                        SetItemChecked( i, values[i] );
+                        SetItemChecked(i, values[i]);
                     }
 
-                    foreach( int i in itemsToRefresh )
+                    foreach (int i in itemsToRefresh)
                     {
-                        SetItemChecked( i, !values[i] );
-                        SetItemChecked( i, values[i] );
+                        SetItemChecked(i, !values[i]);
+                        SetItemChecked(i, values[i]);
                     }
                 }
             }
-            protected override void OnDrawItem( DrawItemEventArgs e )
+            protected override void OnDrawItem(DrawItemEventArgs e)
             {
                 Brush backColorBrush = Brushes.White;
                 Brush foreColorBrush = Brushes.Black;
 
-                switch( (Elements)e.Index )
+                switch ((Elements)e.Index)
                 {
                     case Elements.Fire:
                         backColorBrush = Brushes.Red;
@@ -199,33 +199,33 @@ public bool[] Defaults { get; private set; }
                         break;
                 }
 
-                e.Graphics.FillRectangle( backColorBrush, e.Bounds );
-                CheckBoxState state = this.GetItemChecked( e.Index ) ? CheckBoxState.CheckedNormal : CheckBoxState.UncheckedNormal;
-                Size checkBoxSize = CheckBoxRenderer.GetGlyphSize( e.Graphics, state );
-                Point loc = new Point( 1, (e.Bounds.Height - (checkBoxSize.Height + 1)) / 2 + 1 );
-                CheckBoxRenderer.DrawCheckBox( e.Graphics, new Point( loc.X + e.Bounds.X, loc.Y + e.Bounds.Y ), state );
-                e.Graphics.DrawString( this.Items[e.Index].ToString(), e.Font, foreColorBrush, new PointF( loc.X + checkBoxSize.Width + 1 + e.Bounds.X, loc.Y + e.Bounds.Y ) );
-                
-                if( (Defaults != null) && (Defaults.Length > e.Index) && (Defaults[e.Index] != GetItemChecked( e.Index )) )
+                e.Graphics.FillRectangle(backColorBrush, e.Bounds);
+                CheckBoxState state = this.GetItemChecked(e.Index) ? CheckBoxState.CheckedNormal : CheckBoxState.UncheckedNormal;
+                Size checkBoxSize = CheckBoxRenderer.GetGlyphSize(e.Graphics, state);
+                Point loc = new Point(1, (e.Bounds.Height - (checkBoxSize.Height + 1)) / 2 + 1);
+                CheckBoxRenderer.DrawCheckBox(e.Graphics, new Point(loc.X + e.Bounds.X, loc.Y + e.Bounds.Y), state);
+                e.Graphics.DrawString(this.Items[e.Index].ToString(), e.Font, foreColorBrush, new PointF(loc.X + checkBoxSize.Width + 1 + e.Bounds.X, loc.Y + e.Bounds.Y));
+
+                if ((Defaults != null) && (Defaults.Length > e.Index) && (Defaults[e.Index] != GetItemChecked(e.Index)))
                 {
                     using (Pen p = new Pen(Settings.ModifiedColor.BackgroundColor, 1))
                     {
-                        e.Graphics.DrawRectangle( p, new Rectangle( e.Bounds.X, e.Bounds.Y, e.Bounds.Width - 1, e.Bounds.Height - 1 ) );
+                        e.Graphics.DrawRectangle(p, new Rectangle(e.Bounds.X, e.Bounds.Y, e.Bounds.Width - 1, e.Bounds.Height - 1));
                     }
                 }
 
-                if( !Enabled )
+                if (!Enabled)
                 {
-                    using( SolidBrush disabledRect = new SolidBrush( Color.FromArgb( 100, Color.Gray ) ) )
+                    using (SolidBrush disabledRect = new SolidBrush(Color.FromArgb(100, Color.Gray)))
                     {
-                        e.Graphics.FillRectangle( disabledRect, e.Bounds );
+                        e.Graphics.FillRectangle(disabledRect, e.Bounds);
                     }
                 }
             }
-            protected override void OnKeyDown( KeyEventArgs e )
+            protected override void OnKeyDown(KeyEventArgs e)
             {
-                SetValuesAndDefaults( Defaults, Defaults );
-                base.OnKeyDown( e );
+                SetValuesAndDefaults(Defaults, Defaults);
+                base.OnKeyDown(e);
             }
         }
     }

--- a/Editors/ElementsEditor.cs
+++ b/Editors/ElementsEditor.cs
@@ -19,11 +19,9 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using FFTPatcher.Datatypes;
-using static FFTPatcher.Datatypes.Elements;
 using PatcherLib;
 
 namespace FFTPatcher.Editors
@@ -35,6 +33,19 @@ namespace FFTPatcher.Editors
         private Elements defaults;
         private Elements elements = new Elements(0);
         private bool ignoreChanges = false;
+
+        //Order matters. elementNames[(int)Element.Fire] should be the name of Fire.
+        //However, each name should now be modifiable without causing issues.
+        //  You can change Fire to "Faiya!" and it will use the index instead of the name.
+        private readonly string[] elementNames = new string[] {
+            "Fire",
+            "Lightning",
+            "Ice",
+            "Wind",
+            "Earth",
+            "Water",
+            "Holy",
+            "Dark"};
 
         #endregion Instance Variables 
 
@@ -76,9 +87,8 @@ namespace FFTPatcher.Editors
         {
             if (!ignoreChanges)
             {
-                string s = elementsCheckedListBox.Items[e.Index].ToString();
-                PropertyInfo pi = elements.GetType().GetProperty(s);
-                pi.SetValue(elements, e.NewValue == CheckState.Checked, null);
+                var el = (Element)e.Index;
+                elements[el] = e.NewValue == CheckState.Checked;
                 OnDataChanged(this, System.EventArgs.Empty);
             }
         }

--- a/Editors/Items/ItemEditor.cs
+++ b/Editors/Items/ItemEditor.cs
@@ -25,6 +25,8 @@ using FFTPatcher.Controls;
 using FFTPatcher.Datatypes;
 using PatcherLib.Datatypes;
 using PatcherLib;
+using PatcherLib.Utilities;
+using System.Linq;
 
 namespace FFTPatcher.Editors
 {
@@ -32,23 +34,23 @@ namespace FFTPatcher.Editors
     {
 		#region Instance Variables 
 
-        private List<ComboBoxWithDefault> comboBoxes = new List<ComboBoxWithDefault>();
+        private IList<ComboBoxWithDefault> comboBoxes = new List<ComboBoxWithDefault>();
         private bool ignoreChanges = false;
         private Item item;
         private string[] itemBools = new string[] {
             "Weapon", "Shield", "Head", "Body",
             "Accessory", "Blank1", "Rare", "Blank2" };
-        private List<string> itemFormulaItems;
+        private IList<string> itemFormulaItems;
         private Context ourContext = Context.Default;
-        private List<ItemSubType> pspItemTypes = new List<ItemSubType>( (ItemSubType[])Enum.GetValues( typeof( ItemSubType ) ) );
-        private List<ItemSubType> psxItemTypes = new List<ItemSubType>( (ItemSubType[])Enum.GetValues( typeof( ItemSubType ) ) );
-        private List<LinkLabel> secondTableLinks = new List<LinkLabel>();
-        private List<NumericUpDownWithDefault> spinners = new List<NumericUpDownWithDefault>();
+        private IList<ItemSubType> pspItemTypes = Utilities.GetValues<ItemSubType>().ToList();
+        private IList<ItemSubType> psxItemTypes = Utilities.GetValues<ItemSubType>().ToList();
+        private IList<LinkLabel> secondTableLinks = new List<LinkLabel>();
+        private IList<NumericUpDownWithDefault> spinners = new List<NumericUpDownWithDefault>();
         private string[] weaponBools = new string[] {
             "Striking", "Lunging", "Direct", "Arc",
             "TwoSwords", "TwoHands", "Throwable", "Force2Hands" };
-        private List<string> weaponCastSpellItems;
-        private ShopsFlags[] shops = new ShopsFlags[16] { 
+        private IList<string> weaponCastSpellItems;
+        private IList<ShopsFlags> shops = new ShopsFlags[16] { 
             ShopsFlags.None,
             ShopsFlags.Lesalia, ShopsFlags.Riovanes, ShopsFlags.Igros, ShopsFlags.Lionel,
             ShopsFlags.Limberry, ShopsFlags.Zeltennia, ShopsFlags.Gariland, ShopsFlags.Yardrow,

--- a/Editors/Propositions/ClassBonusesEditor.cs
+++ b/Editors/Propositions/ClassBonusesEditor.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using PatcherLib.Datatypes;
 using FFTPatcher.Datatypes;
 using Lokad;
+using PatcherLib.Utilities;
 
 namespace FFTPatcher.Editors
 {
@@ -41,9 +42,9 @@ namespace FFTPatcher.Editors
 
             UpdateRowHeaders(context);
 
-            foreach (PropositionClass clas in (PropositionClass[])Enum.GetValues( typeof( PropositionClass ) ))
+            foreach (PropositionClass clas in Utilities.GetValues<PropositionClass>())
             {
-                foreach (PropositionType type in (PropositionType[])Enum.GetValues( typeof( PropositionType ) ))
+                foreach (PropositionType type in Utilities.GetValues<PropositionType>())
                 {
                     if (propTypeBonuses.ContainsKey( Tuple.From( type, clas ) ))
                     {
@@ -51,7 +52,7 @@ namespace FFTPatcher.Editors
                     }
                 }
 
-                foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) ))
+                foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
                 {
                     if (bfnBonuses.ContainsKey( Tuple.From( bfn, clas ) ))
                     {
@@ -276,7 +277,7 @@ namespace FFTPatcher.Editors
             PropositionClass destRowClass = (PropositionClass)destRowIndex;
             int sourceRowIndex = source.Index;
 
-            foreach (PropositionType type in (PropositionType[])Enum.GetValues(typeof(PropositionType)))
+            foreach (PropositionType type in Utilities.GetValues<PropositionType>())
             {
                 if (propTypeBonuses.ContainsKey(Tuple.From(type, destRowClass)))
                 {
@@ -284,7 +285,7 @@ namespace FFTPatcher.Editors
                 }
             }
                 
-            foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues(typeof(BraveFaithNeutral)))
+            foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
                 if (bfnBonuses.ContainsKey(Tuple.From(bfn, destRowClass)))
                 {

--- a/Editors/Propositions/StatLevelBonusesEditor.cs
+++ b/Editors/Propositions/StatLevelBonusesEditor.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using PatcherLib.Datatypes;
 using FFTPatcher.Datatypes;
 using Lokad;
+using PatcherLib.Utilities;
 
 namespace FFTPatcher.Editors
 {
@@ -49,9 +50,9 @@ namespace FFTPatcher.Editors
 
             UpdateRowHeaders( context );
 
-            foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) ))
+            foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
-                foreach (BraveFaithRange bfr in (BraveFaithRange[])Enum.GetValues( typeof( BraveFaithRange ) ))
+                foreach (BraveFaithRange bfr in Utilities.GetValues<BraveFaithRange>())
                 {
                     var thisTuple = Tuple.From( bfn, bfr );
                     if (braveBonuses.ContainsKey( thisTuple ))
@@ -65,7 +66,7 @@ namespace FFTPatcher.Editors
                     }
                 }
 
-                foreach (LevelRange lr in (LevelRange[])Enum.GetValues( typeof( LevelRange ) ))
+                foreach (LevelRange lr in Utilities.GetValues<LevelRange>())
                 {
                     if (levelBonuses.ContainsKey( Tuple.From( bfn, lr ) ))
                     {
@@ -428,7 +429,7 @@ namespace FFTPatcher.Editors
             LevelRange destRowLR = (LevelRange)destRowIndex;
             int sourceRowIndex = source.Index;
 
-            foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues(typeof(BraveFaithNeutral)))
+            foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
                 //var thisTuple = Tuple.From(bfn, destRowBFR);
 
@@ -453,9 +454,9 @@ namespace FFTPatcher.Editors
 }
 
 /*
-           foreach (BraveFaithNeutral bfn in (BraveFaithNeutral[])Enum.GetValues( typeof( BraveFaithNeutral ) ))
+           foreach (BraveFaithNeutral bfn in Utilities.GetValues<BraveFaithNeutral>())
             {
-                foreach (BraveFaithRange bfr in (BraveFaithRange[])Enum.GetValues( typeof( BraveFaithRange ) ))
+                foreach (BraveFaithRange bfr in Utilities.GetValues<BraveFaithRange>())
                 {
                     var thisTuple = Tuple.From( bfn, bfr );
                     if (braveBonuses.ContainsKey( thisTuple ))
@@ -469,7 +470,7 @@ namespace FFTPatcher.Editors
                     }
                 }
 
-                foreach (LevelRange lr in (LevelRange[])Enum.GetValues( typeof( LevelRange ) ))
+                foreach (LevelRange lr in Utilities.GetValues<LevelRange>())
                 {
                     if (levelBonuses.ContainsKey( Tuple.From( bfn, lr ) ))
                     {

--- a/PatcherLib/Datatypes/SubArray.cs
+++ b/PatcherLib/Datatypes/SubArray.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using PatcherLib.Utilities;
+using System.Linq;
 
 namespace PatcherLib.Datatypes
 {
@@ -151,11 +152,6 @@ internal class CollectionDebugView<T>
     public T[] Items
     {
         get { return collection.ToArray(); }
-    }
-
-    public CollectionDebugView( IList<T> collection )
-        : this( collection as IEnumerable<T> )
-    {
     }
 
     public CollectionDebugView( IEnumerable<T> collection )

--- a/PatcherLib/ExtensionMethods.cs
+++ b/PatcherLib/ExtensionMethods.cs
@@ -86,18 +86,6 @@ namespace PatcherLib.Utilities
             return -1;
         }
 
-        public static T[] ToArray<T>( this IEnumerable<T> collection )
-        {
-            return collection.ToList().ToArray();
-        }
-
-        public static IList<T> ToList<T>( this IEnumerable<T> collection )
-        {
-            if (collection is IList<T>)
-                return new ReadOnlyCollection<T>( collection as IList<T> );
-
-            return new List<T>( collection ).AsReadOnly();
-        }
         public static IList<T> SetAll<T>(this IList<T> list, T value)
         {
             for (int i = 0; i < list.Count; i++)

--- a/PatcherLib/Utilities.cs
+++ b/PatcherLib/Utilities.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -455,6 +456,22 @@ namespace PatcherLib.Utilities
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Shim for Enum.GetValues&lt;T&gt;() (added in .NET 5).
+        /// </summary>
+        /// <typeparam name="TEnum"></typeparam>
+        /// <returns></returns>
+        public static IEnumerable<TEnum> GetValues<TEnum>()
+        {
+            return Enum.GetValues(typeof(TEnum)).Cast<TEnum>();
+        }
+
+        public static string[] GetEnumNames<T>()
+        {
+            var values = Enum.GetValues(typeof(T)).Cast<T>();
+            return values.Select(el => el.ToString()).ToArray();
         }
 
         public static bool TryParseInt(string str, out int value)

--- a/PatcherLib/Utilities.cs
+++ b/PatcherLib/Utilities.cs
@@ -463,9 +463,9 @@ namespace PatcherLib.Utilities
         /// </summary>
         /// <typeparam name="TEnum"></typeparam>
         /// <returns></returns>
-        public static IEnumerable<TEnum> GetValues<TEnum>()
+        public static TEnum[] GetValues<TEnum>()
         {
-            return Enum.GetValues(typeof(TEnum)).Cast<TEnum>();
+            return Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToArray();
         }
 
         public static string[] GetEnumNames<T>()

--- a/PatcherLib/Utilities.cs
+++ b/PatcherLib/Utilities.cs
@@ -324,7 +324,7 @@ namespace PatcherLib.Utilities
         }
 
         /// <summary>
-        /// Builds a byte from the passed booleans.
+        /// Builds a byte from the passed booleans, with most-significant bit first.
         /// </summary>
         public static byte ByteFromBooleans( bool msb, bool six, bool five, bool four, bool three, bool two, bool one, bool lsb )
         {

--- a/ShishiSpriteEditor/Controls/SpriteEditor.cs
+++ b/ShishiSpriteEditor/Controls/SpriteEditor.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using System.IO;
 using PatcherLib.Utilities;
 using FFTPatcher.SpriteEditor.DataTypes;
+using System.Linq;
 
 namespace FFTPatcher.SpriteEditor
 {
@@ -35,7 +36,7 @@ namespace FFTPatcher.SpriteEditor
         public SpriteEditor()
         {
             InitializeComponent();
-            var s = new List<SpriteType>((SpriteType[])Enum.GetValues(typeof(SpriteType)));
+            var s = Utilities.GetValues<SpriteType>().ToList();
             //s.Remove(SpriteType.RUKA);
 
             shpComboBox.DataSource = s.ToArray();


### PR DESCRIPTION
- Preparation for changing element names in the editor. It should no longer look up elements by editor name at any point, so the editor name can be changed.
- Refactor enum enumeration throughout. (Newer .NET versions have `Enum.GetValues<EType>`, which should replace that.)
- Fix reversed Element read in XML. (Not that it's used.)
- Removed Elements redundancy.
- Removed some Utilities methods which were in LINQ already.

Warning: You may decide to change the names of my new classes.

Warning: The old Utilities.ToList used to return a readonly list. But since the way it was used (i.e. didn't save to a readonly-typed var) doesn't give a compiler warning, who cares? Besides, I bet it was misused and caused crashes at some points.