### PR TITLE
improve label for RSM Ability ID to differentiate from overall Ability ID

### DIFF
--- a/Editors/Abilities/AbilityEditor.Designer.cs
+++ b/Editors/Abilities/AbilityEditor.Designer.cs
@@ -152,7 +152,7 @@ namespace FFTPatcher.Editors
             idLabel.Name = "idLabel";
             idLabel.Size = new System.Drawing.Size(51, 13);
             idLabel.TabIndex = 21;
-            idLabel.Text = "Ability ID:";
+            idLabel.Text = "RSM Ability ID:";
             // 
             // arithmeticksLabel
             // 


### PR DESCRIPTION
Change label in Patcher to more clearly differentiate between "Ability ID" (the number in the column on the left) and "RSM Ability ID" from the secondary table.

<img width="1148" height="889" alt="image" src="https://github.com/user-attachments/assets/9c1bef4f-0d85-487d-bc0f-7934cfaa0b10" />