### PR TITLE
Update PSPImages.xml

### DIFF
--- a/ShishiSpriteEditor/PSPImages.xml
+++ b/ShishiSpriteEditor/PSPImages.xml
@@ -1674,8 +1674,10 @@
             <Name>Onion Knight Female</Name>
             <Name>Balthier</Name>
             <Name>Luso</Name>
+            <Name>Bremondt Freitberg</Name>
+            <Name>Aliste Rosenheim</Name>
         </Names>
-        <Repeat Number="6" Offset="800" PaletteOffset="800">
+        <Repeat Number="8" Offset="800" PaletteOffset="800">
             <PalettedImage4bpp>
                 <Width>32</Width>
                 <Height>48</Height>


### PR DESCRIPTION
Apparently I can't count, there were 8 images not 6 before end of file
It seems that Argaths special encounter doesn't have its own portrait sprite other than the one on his sprite sheet

Also double checked HCHAR.DAT still only the 6 formation sprites there before end of file, which makes sense since no other WOTL party members were added